### PR TITLE
add AWSKMS vars and Jinja templating

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,32 @@ Ansible variables are listed below, along with default values (see `defaults/mai
 - Name of the KMS Key in GCP
 - Default value: None
 
+### `vault_seal_aws_region`
+
+- AWS region the KMS lives in
+- Default value: None
+
+### `vault_seal_aws_access_key`
+
+- Name of the AWS access key
+- Default value: None
+
+### `vault_seal_aws_secret_key`
+
+- Name of the AWS secret key
+- Default value: None
+
+### `vault_seal_aws_kms_key_id`
+
+- AWS KMS key ID
+- Default value: None
+
+### `vault_seal_aws_endpoint`
+
+- (optional) AWS KMS API endpoint. If not set, default API endpoint for region will be used.
+- Default value: None
+- [Vault API ref](https://www.vaultproject.io/docs/configuration/seal/awskms#endpoint)
+
 ### `vault_hsm_crypto_library`
 
 - Path to the HSM's local crypto library

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -55,6 +55,16 @@ seal "gcpckms" {
   key_ring    = "{{ vault_seal_gcp_key_ring }}"
   crypto_key  = "{{ vault_seal_gcp_crypto_key }}"
 }
+{% elif vault_seal_type == "awskms" %}
+seal "awskms" {
+  region     = "{{ vault_seal_aws_region }}"
+  access_key = "{{ vault_seal_aws_access_key }}"
+  secret_key = "{{ vault_seal_aws_secret_key }}"
+  kms_key_id = "{{ vault_seal_aws_kms_key_id }}"
+{% if vault_seal_aws_endpoint is defined %}
+  endpoint   = "{{ vault_seal_aws_endpoint }}"
+{% endif %}
+}
 {% elif vault_seal_type == "pkcs11" %}
 seal "pkcs11" { 
   lib            = "{{ vault_hsm_crypto_library }}"


### PR DESCRIPTION
Hi Jacob,
This PR introduces Ansible vars for AWSKMS and updates README accordingly.

```
vault_seal_aws_region
vault_seal_aws_access_key
vault_seal_aws_secret_key
vault_seal_aws_kms_key_id
# (next one is optional)
vault_seal_aws_endpoint
```

Details on AWS endpoint, see [Vault API ref](https://www.vaultproject.io/docs/configuration/seal/awskms#endpoint)