### PR TITLE
add support for `cluster_name` config stanza

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Ansible variables are listed below, along with default values (see `defaults/mai
 - Vault API port
 - Default value: `8200`
 
+### `vault_cluster_name`
+- The name of the Vault cluster
+- Default value: none
+
 ### `vault_cluster_port`
 - Vault cluster port
 - Default value: `8201`

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -1,3 +1,7 @@
+{% if vault_cluster_name is defined and vault_cluster_name != '' -%}
+cluster_name = "{{ vault_cluster_name }}"
+
+{% endif -%}
 listener "tcp" {
 {% if vault_tls_cert_file is defined and vault_tls_key_file is defined %}
 {% set proto="https" %}

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -1,7 +1,7 @@
-{% if vault_cluster_name is defined and vault_cluster_name != '' -%}
+{% if vault_cluster_name is defined %}
 cluster_name = "{{ vault_cluster_name }}"
+{% endif %}
 
-{% endif -%}
 listener "tcp" {
 {% if vault_tls_cert_file is defined and vault_tls_key_file is defined %}
 {% set proto="https" %}


### PR DESCRIPTION
this commit adds support for managing the `cluster_name` setting the Vault's configuration. This is required for [Telegraf when working with Splunk](https://learn.hashicorp.com/tutorials/vault/monitor-telemetry-audit-splunk#configure-vault).