### PR TITLE
Allow passing the Vault license as a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ Ansible variables are listed below, along with default values (see `defaults/mai
 - If set, Ansible will locally look for the Vault binary at the specified path 
 - No default value
 
+### `vault_license_string`
+- If set, Ansible will create a lincense file using this value for the file content
+- No default value. A license is **required** for Vault versions >= 1.8.0 when installing enterprise, so **you have to provide** either `vault_license_string` or `vault_license_file`
+
 ### `vault_license_file`
 - If set, Ansible will locally look for a Vault license at the specifed path
-- No default value. This is **required** for Vault versions >= 1.8.0 when installing enterprise
+- No default value. A license is **required** for Vault versions >= 1.8.0 when installing enterprise, so **you have to provide** either `vault_license_string` or `vault_license_file`
 
 ### `vault_client_addr`
 - The address to which Vault will bind client interfaces

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Checking input variables
+  fail:
+    msg: You can't use vault_license_file and vault_license_file at the same time
+  when: vault_license_file is defined and vault_license_string is defined
+
 - name: Installing Vault via the HashiCorp repository
   include_tasks: repository_install.yml
   when: use_hashicorp_repository

--- a/tasks/non_packer_install.yml
+++ b/tasks/non_packer_install.yml
@@ -18,12 +18,22 @@
 - name: Copying Vault license file
   ansible.builtin.copy:
     src: '{{ vault_license_file }}'
-    dest: '{{ vault_license_directory }}/{{ vault_license_file | basename }}'
+    dest: '{{ vault_license_directory }}/vault.hclic'
     owner: '{{ vault_user }}'
     group: '{{ vault_group }}'
     mode: '0400'
   when:
     - vault_license_file is defined
+
+- name: Creating Vault license file
+  ansible.builtin.copy:
+    dest: '{{ vault_license_directory }}/vault.hclic'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+    mode: '0400'
+    content: '{{ vault_license_string }}'
+  when:
+    - vault_license_string is defined
 
 - name: Templating out Vault configuration
   ansible.builtin.template:

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -106,8 +106,8 @@ seal "{{ vault_seal.type }}" {
 plugin_directory = "{{ vault_plugin_directory }}"
 {% endif %}
 
-{% if vault_license_file is defined %}
-license_path = "{{ vault_license_directory }}/{{ vault_license_file | basename }}"
+{% if vault_license_file is defined or vault_license_string is defined %}
+license_path = "{{ vault_license_directory }}/vault.hclic"
 {% endif %}
 
 api_addr      = "{{ proto }}://{{ ansible_fqdn }}:{{ vault_api_port }}"


### PR DESCRIPTION
Having a license file on a host is not a viable option for everyone.

By passing the license as a string, then it can be stored as a secret in
Ansible or retrieved from an external data source.

This PR adds a new option without removing the existing `vault_license_file`
functionality.

To simplify the code, this commit changes the existing tasks to now use
`vault.hclic` for the license filename, regardless of the method used to
supply the license.
