### PR TITLE
Allow passing the Vault license and TLS certs as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ Ansible variables are listed below, along with default values (see `defaults/mai
 - Default value: `https://releases.hashicorp.com/vault/1.9.1/vault_1.9.1_linux_amd64.zip`
 
 ### `vault_local_binary_location`
-- If set, Ansible will locally look for the Vault binary at the specified path 
+- If set, Ansible will locally look for the Vault binary at the specified path
 - No default value
 
 ### `vault_license_file`
-- If set, Ansible will locally look for a Vault license at the specifed path
+- If set, Ansible will locally look for a Vault license at the specified path
 - No default value. This is **required** for Vault versions >= 1.8.0 when installing enterprise
 
 ### `vault_client_addr`
@@ -135,19 +135,31 @@ Ansible variables are listed below, along with default values (see `defaults/mai
 - Default value: true
 
 ### `vault_tls_ca_cert_file`
-- If set, Ansible will locally look for a TLS CA certificate at the specified path to copy to each Vault server
+- If set, Ansible will locally look for a TLS CA certificate at the specified path to copy to each Vault server. Mutually exclusive with `vault_tls_ca_cert_string`
+- No default value
+
+### `vault_tls_ca_cert_string`
+- If set, Ansible will Ansible will create the TLS CA file using this value for the file content. Mutually exclusive with `vault_tls_ca_cert_file`
 - No default value
 
 ### `vault_tls_cert_file`
-- If set, Ansible will locally look for a signed TLS certificate at the specified path to copy to each Vault server
+- If set, Ansible will locally look for a TLS certificate at the specified path to copy to each Vault server. Mutually exclusive with `vault_tls_cert_string`
+- No default value
+
+### `vault_tls_cert_string`
+- If set, Ansible will Ansible will create the TLS certificate using this value for the file content. Mutually exclusive with `vault_tls_cert_file`
 - No default value
 
 ### `vault_tls_key_file`
-- If set, Ansible will locally look for a TLS key at the specified path to copy to each Vault server
+- If set, Ansible will locally look for a TLS key at the specified path to copy to each Vault server. Mutually exclusive with `vault_tls_key_string`
+- No default value
+
+### `vault_tls_key_string`
+- If set, Ansible will Ansible will create the TLS key using this value for the file content. Mutually exclusive with `vault_tls_cert_file`
 - No default value
 
 ### `vault_leader_tls_servername`
-- If Set, Vault will use this TLS servername when connecting with HTTPS. Uses the server's hostname if not set.
+- If Set, Vault will use this TLS server name when connecting with HTTPS. Uses the server's hostname if not set.
 - No default value
 
 ### `consul_http_port`
@@ -179,7 +191,7 @@ Ansible variables are listed below, along with default values (see `defaults/mai
 - No default value
 
 ### `consul_tls_skip_verify`
-- If true, Vault will skip verification of the certificae presented by Consul
+- If true, Vault will skip verification of the certificate presented by Consul
 - Default value: `false`
 
 ### `consul_vault_kv_path`

--- a/README.md
+++ b/README.md
@@ -88,9 +88,13 @@ Ansible variables are listed below, along with default values (see `defaults/mai
 - If set, Ansible will locally look for the Vault binary at the specified path
 - No default value
 
+### `vault_license_string`
+- If set, Ansible will create a license file using this value for the file content
+- No default value. A license is **required** for Vault versions >= 1.8.0 when installing enterprise, so **you have to provide** either `vault_license_string` or `vault_license_file`
+
 ### `vault_license_file`
 - If set, Ansible will locally look for a Vault license at the specified path
-- No default value. This is **required** for Vault versions >= 1.8.0 when installing enterprise
+- No default value. A license is **required** for Vault versions >= 1.8.0 when installing enterprise, so **you have to provide** either `vault_license_string` or `vault_license_file`
 
 ### `vault_client_addr`
 - The address to which Vault will bind client interfaces

--- a/tasks/check_input.yml
+++ b/tasks/check_input.yml
@@ -1,0 +1,16 @@
+---
+- name: Checking TLS CA input variables
+  fail:
+    msg: You can't use vault_tls_ca_cert_file and vault_tls_ca_cert_string at the same time
+  when: vault_tls_ca_cert_file is defined and vault_tls_ca_cert_string is defined
+
+- name: Checking TLS cert input variables
+  fail:
+    msg: You can't use vault_tls_cert_file and vault_tls_cert_string at the same time
+  when: vault_tls_cert_file is defined and vault_tls_cert_string is defined
+
+- name: Checking TLS key input variables
+  fail:
+    msg: You can't use vault_tls_key_file and vault_tls_key_string at the same time
+  when: vault_tls_key_file is defined and vault_tls_key_string is defined
+

--- a/tasks/check_input.yml
+++ b/tasks/check_input.yml
@@ -14,3 +14,7 @@
     msg: You can't use vault_tls_key_file and vault_tls_key_string at the same time
   when: vault_tls_key_file is defined and vault_tls_key_string is defined
 
+- name: Checking license input variables
+  fail:
+    msg: You can't use vault_license_file and vault_license_file at the same time
+  when: vault_license_file is defined and vault_license_string is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- name: Checking input variables
+  include_tasks: check_input.yml
+
 - name: Installing Vault via the HashiCorp repository
   include_tasks: repository_install.yml
   when: use_hashicorp_repository

--- a/tasks/non_packer_install.yml
+++ b/tasks/non_packer_install.yml
@@ -1,19 +1,60 @@
-- name: Copying TLS certificates
+- name: Copying TLS CA certificate
   ansible.builtin.copy:
-    src: '{{ item }}'
-    dest: '{{ vault_tls_directory }}/{{ item | basename }}'
+    src: '{{ vault_tls_ca_cert_file }}'
+    dest: '{{ vault_tls_directory }}/ca.crt'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+    mode: '0400'
+  when:
+    - vault_tls_ca_cert_file is defined
+  notify:
+    - Restart Vault
+
+- name: Copying TLS certificate and key
+  ansible.builtin.copy:
+    src: '{{ item.src }}'
+    dest: '{{ vault_tls_directory }}/{{ item.dest }}'
     owner: '{{ vault_user }}'
     group: '{{ vault_group }}'
     mode: '0400'
   with_items:
-    - '{{ vault_tls_ca_cert_file | default([]) }}'
-    - '{{ vault_tls_cert_file }}'
-    - '{{ vault_tls_key_file }}'
+    - { src: '{{ vault_tls_cert_file }}', dest: 'vault.crt' }
+    - { src: '{{ vault_tls_key_file }}', dest: 'vault.key' }
   when:
     - vault_tls_cert_file is defined
     - vault_tls_key_file is defined
   notify:
     - Restart Vault
+
+- name: Creating TLS CA cert file
+  ansible.builtin.copy:
+    dest: '{{ vault_tls_directory }}/ca.crt'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+    mode: '0644'
+    content: '{{ vault_tls_ca_cert_string }}'
+  when:
+    - vault_tls_ca_cert_string is defined
+
+- name: Creating TLS cert file
+  ansible.builtin.copy:
+    dest: '{{ vault_tls_directory }}/vault.crt'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+    mode: '0644'
+    content: '{{ vault_tls_cert_string }}'
+  when:
+    - vault_tls_cert_string is defined
+
+- name: Creating TLS key file
+  ansible.builtin.copy:
+    dest: '{{ vault_tls_directory }}/vault.key'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+    mode: '0644'
+    content: '{{ vault_tls_key_string }}'
+  when:
+    - vault_tls_key_string is defined
 
 - name: Copying Vault license file
   ansible.builtin.copy:

--- a/tasks/non_packer_install.yml
+++ b/tasks/non_packer_install.yml
@@ -59,12 +59,22 @@
 - name: Copying Vault license file
   ansible.builtin.copy:
     src: '{{ vault_license_file }}'
-    dest: '{{ vault_license_directory }}/{{ vault_license_file | basename }}'
+    dest: '{{ vault_license_directory }}/vault.hclic'
     owner: '{{ vault_user }}'
     group: '{{ vault_group }}'
     mode: '0400'
   when:
     - vault_license_file is defined
+
+- name: Creating Vault license file
+  ansible.builtin.copy:
+    dest: '{{ vault_license_directory }}/vault.hclic'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+    mode: '0400'
+    content: '{{ vault_license_string }}'
+  when:
+    - vault_license_string is defined
 
 - name: Templating out Vault configuration
   ansible.builtin.template:

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -106,8 +106,8 @@ seal "{{ vault_seal.type }}" {
 plugin_directory = "{{ vault_plugin_directory }}"
 {% endif %}
 
-{% if vault_license_file is defined %}
-license_path = "{{ vault_license_directory }}/{{ vault_license_file | basename }}"
+{% if vault_license_file is defined or vault_license_string is defined %}
+license_path = "{{ vault_license_directory }}/vault.hclic"
 {% endif %}
 
 api_addr      = "{{ proto }}://{{ ansible_fqdn }}:{{ vault_api_port }}"

--- a/templates/vault.hcl.j2
+++ b/templates/vault.hcl.j2
@@ -3,11 +3,11 @@ cluster_name = "{{ vault_cluster_name }}"
 {% endif %}
 
 listener "tcp" {
-{% if vault_tls_cert_file is defined and vault_tls_key_file is defined %}
+{% if (vault_tls_cert_file is defined or vault_tls_cert_string is defined) and (vault_tls_key_file is defined or vault_tls_key_string is defined) %}
 {% set proto="https" %}
   address                  = "{{ vault_client_addr }}:{{ vault_api_port }}"
-  tls_cert_file            = "{{ vault_tls_directory }}/{{ vault_tls_cert_file | basename }}"
-  tls_key_file             = "{{ vault_tls_directory }}/{{ vault_tls_key_file  | basename }}"
+  tls_cert_file            = "{{ vault_tls_directory }}/vault.crt"
+  tls_key_file             = "{{ vault_tls_directory }}/vault.key"
   tls_disable_client_certs = {{ vault_tls_disable_client_certs | lower }}
 {% else %}
 {% set proto="http" %}
@@ -32,12 +32,12 @@ storage "raft" {
   retry_join {
     leader_api_addr         = "{{ proto }}://{{ hostvars[vault_server]['ansible_fqdn'] }}:{{ vault_api_port }}"
 {% if proto == "https" %}
-{% if vault_tls_ca_cert_file is defined %}
-    leader_ca_cert_file     = "{{ vault_tls_directory }}/{{ vault_tls_ca_cert_file | basename }}"
+{% if vault_tls_ca_cert_file is defined or vault_tls_ca_cert_string is defined %}
+    leader_ca_cert_file     = "{{ vault_tls_directory }}/ca.crt"
 {% endif %}
 {% if not vault_tls_disable_client_certs %}
-    leader_client_cert_file = "{{ vault_tls_directory }}/{{ vault_tls_cert_file | basename }}"
-    leader_client_key_file  = "{{ vault_tls_directory }}/{{ vault_tls_key_file  | basename }}"
+    leader_client_cert_file = "{{ vault_tls_directory }}/vault.crt"
+    leader_client_key_file  = "{{ vault_tls_directory }}/vault.key"
 {% endif %}
 {% endif %}
   }
@@ -52,8 +52,8 @@ storage "raft" {
     auto_join             = "provider=aws tag_key={{ cloud.aws_tag_key }} tag_value={{ cloud.aws_tag_value }}"
 {% endif %}
     auto_join_scheme      = "https"
-{% if vault_tls_ca_cert_file is defined %}
-    leader_ca_cert_file   = "{{ vault_tls_directory }}/{{ vault_tls_ca_cert_file | basename }}"
+{% if vault_tls_ca_cert_file is defined or vault_tls_ca_cert_string is defined %}
+    leader_ca_cert_file   = "{{ vault_tls_directory }}/ca.crt"
 {% endif %}
     leader_tls_servername = "{{ vault_leader_tls_servername | default(ansible_fqdn) }}"
   }


### PR DESCRIPTION
Having a sensitive files on a host where you run Ansible from is not a viable option for everyone.

By passing the license and TLS certificates as strings, then they can be stored as secrets in
Ansible or retrieved from an external data source.

This adds a new option without removing the existing `vault_tls_*_file` and `vault_license_file` functionality.

To simplify the code, this PR changes the existing tasks to use hardcoded names for the affected files.

This supersedes #27 
