### PR TITLE
Use the vault unit that comes from the RPM/dpkg.

### DIFF
--- a/tasks/non_packer_install.yml
+++ b/tasks/non_packer_install.yml
@@ -95,6 +95,8 @@
     mode: '0644'
   notify:
     - Reload Vault daemon
+  when:
+    - not use_hashicorp_repository
 
 - name: Starting and enabling Vault
   ansible.builtin.systemd:


### PR DESCRIPTION
This file does not need to be place when using a package, the package already contains the unit file. @fvoges, I think this would help us for the current project.