### PR TITLE
add support for vault.env for zip binary installs

### DIFF
--- a/tasks/non_packer_install.yml
+++ b/tasks/non_packer_install.yml
@@ -86,6 +86,16 @@
   notify:
     - Restart Vault
 
+- name: Creating service environment file
+  ansible.builtin.file:
+    path: '{{ vault_home_directory }}/vault.env'
+    owner: '{{ vault_user }}'
+    group: '{{ vault_group }}'
+    mode: '0640'
+    state: touch
+  notify:
+    - Reload Vault daemon
+
 - name: Templating out systemd script
   ansible.builtin.template:
     src: vault.systemd.j2

--- a/templates/vault.systemd.j2
+++ b/templates/vault.systemd.j2
@@ -8,6 +8,7 @@ StartLimitIntervalSec=60
 StartLimitBurst=3
 
 [Service]
+EnvironmentFile={{ vault_home_directory }}/vault.env
 User={{ vault_user }}
 Group={{ vault_group }}
 ProtectSystem=full


### PR DESCRIPTION
the Vault packages support adding environment variables to the Vault service by loading  /etc/vault.d/vault.env from the systemd unit file

this change adds the same functionality for the zip binary installation. With default settings, the Vault unit file should now loook exactly like the one included in the official packages