### PR TITLE
fix debian package version string handling

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,6 +28,8 @@ vault_architecture_map:
   aarch64: arm64
 
 vault_version: '1.11.3'
+vault_package_revision: ''
+
 vault_os: '{{ ansible_system|lower }}'
 vault_architecture: '{{ vault_architecture_map[ansible_architecture] }}'
 vault_archive: 'vault_{{ vault_version }}_{{ vault_os }}_{{ vault_architecture }}.zip'

--- a/tasks/repository_install.yml
+++ b/tasks/repository_install.yml
@@ -66,7 +66,7 @@
 - name: Installing Vault package via apt
   ansible.builtin.apt:
     name:
-      - "vault={{ vault_version }}"
+      - "vault={{ vault_version }}{{ (vault_package_revision == '') | ternary('', '-' ~ vault_package_revision) }}"
     state: present
     update_cache: true
   when:
@@ -76,7 +76,7 @@
 - name: Installing Vault enterprise package via apt
   ansible.builtin.apt:
     name:
-      - "vault-enterprise={{ vault_version }}+ent"
+      - "vault-enterprise={{ vault_version }}+ent{{ (vault_package_revision == '') | ternary('', '-' ~ vault_package_revision) }}"
     state: present
     update_cache: true
   when:


### PR DESCRIPTION
this commit adds a vault_package_revision input to allow to specify the package revision number. this is use by the debian package tasks to build the package version string